### PR TITLE
Fix ConfigMap update bugs and add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # Test binary, built with `go test -c`
 *.test
 
+# Compiled binary produced by `make build`
+/vault-operator-helper
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -29,8 +30,12 @@ var (
 	watchKey           string
 	mainContainerName  string
 
-	clientset *kubernetes.Clientset
+	clientset kubernetes.Interface
 	lock      sync.Mutex
+
+	// restartMainContainer is the action used to reload the ConfigMap.
+	// It is a variable so tests can override it.
+	restartMainContainer = killMainContainer
 )
 
 func init() {
@@ -40,12 +45,12 @@ func init() {
 	flag.StringVar(&labelSelector, "label-selector", "foo=bar", "Label selector for namespaces to watch")
 	flag.StringVar(&watchKey, "watch-key", "WATCH_NAMESPACE", "Key in the ConfigMap to store namespace list")
 	flag.StringVar(&mainContainerName, "main-container", "main-container", "Name of the main container to restart")
-
-	// Parse flags
-	flag.Parse()
 }
 
 func main() {
+	// Parse flags
+	flag.Parse()
+
 	config, err := getKubeConfig()
 	if err != nil {
 		fmt.Printf("Error getting Kubernetes config: %v\n", err)
@@ -64,9 +69,6 @@ func main() {
 	// Set up signal handling for graceful shutdown
 	stopCh := make(chan struct{})
 	signalCh := make(chan os.Signal, 1)
-
-	// Listen for termination signals
-	signal.Notify(signalCh, syscall.SIGTERM, syscall.SIGINT)
 
 	// Listen for termination signals
 	signal.Notify(signalCh, syscall.SIGTERM, syscall.SIGINT)
@@ -143,8 +145,12 @@ func updateConfigMap() {
 	// Fetch the existing ConfigMap
 	cm, err := clientset.CoreV1().ConfigMaps(configMapNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
 	if err != nil {
-		// If ConfigMap doesn't exist, create it
-		createConfigMap(newValue)
+		if apierrors.IsNotFound(err) {
+			// If ConfigMap doesn't exist, create it
+			createConfigMap(newValue)
+		} else {
+			fmt.Printf("Error getting ConfigMap: %v\n", err)
+		}
 		return
 	}
 
@@ -153,7 +159,10 @@ func updateConfigMap() {
 		return
 	}
 
-	// Update ConfigMap
+	// Update ConfigMap (Data may be nil if the ConfigMap was created without any data)
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
 	cm.Data[watchKey] = newValue
 	_, err = clientset.CoreV1().ConfigMaps(configMapNamespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
 	if err != nil {
@@ -162,7 +171,7 @@ func updateConfigMap() {
 	}
 
 	// Trigger restart of the main container
-	killMainContainer()
+	restartMainContainer()
 }
 
 // getFilteredNamespaces retrieves namespaces with the specified label

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// setupTest configures the package globals for a test run and returns the fake
+// clientset so assertions can be made against it. The main-container restart is
+// stubbed out so tests never shell out to pgrep/kill.
+func setupTest(t *testing.T, objects ...runtime.Object) *fake.Clientset {
+	t.Helper()
+
+	cs := fake.NewSimpleClientset(objects...)
+
+	configMapName = "watch-namespace-config"
+	configMapNamespace = "vault"
+	watchKey = "WATCH_NAMESPACE"
+	// Empty selector: the fake clientset does not apply label-selector filtering,
+	// so keep tests independent of that behaviour.
+	labelSelector = ""
+
+	clientset = cs
+
+	restartMainContainer = func() {}
+	t.Cleanup(func() { restartMainContainer = killMainContainer })
+
+	return cs
+}
+
+func TestGetFilteredNamespaces(t *testing.T) {
+	setupTest(t,
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-a"}},
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-b"}},
+	)
+
+	got, err := getFilteredNamespaces()
+	if err != nil {
+		t.Fatalf("getFilteredNamespaces returned error: %v", err)
+	}
+
+	want := map[string]bool{"team-a": true, "team-b": true}
+	if len(got) != len(want) {
+		t.Fatalf("got %d namespaces (%v), want %d", len(got), got, len(want))
+	}
+	for _, ns := range got {
+		if !want[ns] {
+			t.Errorf("unexpected namespace %q in result", ns)
+		}
+	}
+}
+
+func TestUpdateConfigMap_CreatesWhenMissing(t *testing.T) {
+	cs := setupTest(t,
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-a"}},
+	)
+
+	updateConfigMap()
+
+	cm, err := cs.CoreV1().ConfigMaps(configMapNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected ConfigMap to be created, got error: %v", err)
+	}
+	if cm.Data[watchKey] != "team-a" {
+		t.Errorf("got %q, want %q", cm.Data[watchKey], "team-a")
+	}
+}
+
+// TestUpdateConfigMap_NilData is a regression test: updating an existing
+// ConfigMap whose Data map is nil must not panic.
+func TestUpdateConfigMap_NilData(t *testing.T) {
+	cs := setupTest(t,
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-a"}},
+		&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "watch-namespace-config", Namespace: "vault"},
+			// Data intentionally nil.
+		},
+	)
+
+	// Would panic before the nil-map guard was added.
+	updateConfigMap()
+
+	cm, err := cs.CoreV1().ConfigMaps(configMapNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get ConfigMap: %v", err)
+	}
+	if cm.Data[watchKey] != "team-a" {
+		t.Errorf("got %q, want %q", cm.Data[watchKey], "team-a")
+	}
+}
+
+func TestUpdateConfigMap_NoChangeKeepsValue(t *testing.T) {
+	cs := setupTest(t,
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-a"}},
+		&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "watch-namespace-config", Namespace: "vault"},
+			Data:       map[string]string{"WATCH_NAMESPACE": "team-a"},
+		},
+	)
+
+	updateConfigMap()
+
+	cm, err := cs.CoreV1().ConfigMaps(configMapNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get ConfigMap: %v", err)
+	}
+	if cm.Data[watchKey] != "team-a" {
+		t.Errorf("got %q, want %q", cm.Data[watchKey], "team-a")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes several real bugs in `main.go` and adds unit-test coverage.

### Bug fixes
- **Remove duplicate `signal.Notify`** — the same registration was made twice.
- **Avoid nil-map panic** — updating an existing ConfigMap whose `Data` map is `nil` previously panicked on assignment; now the map is initialized first.
- **Correct `Get` error handling** — only create the ConfigMap on a genuine `NotFound`; other errors (e.g. transient API failures) are logged instead of being treated as "does not exist".

### Maintainability
- Move `flag.Parse()` from `init()` into `main()` so it no longer interferes with `go test` flag parsing.
- Change `clientset` to `kubernetes.Interface` and add an injectable restart hook, enabling unit tests with a fake clientset.
- Ignore the `make build` binary in `.gitignore`.

### Tests
Added `main_test.go` covering namespace filtering and the ConfigMap create/update paths, including a regression test for the nil-map panic.

## Verification
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ (4 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)