### PR TITLE
Simplify CI matrix and harden build config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,25 +11,27 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        go:
-          - '1.21'
-          - '1.22'
-          - '1.23'
-          - '1.24'
-          - '1.25'
-          - '1.26'
-
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: go.mod
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Go vet
+        run: make vet
 
       - name: Go test
         run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -o vault-operator-helper main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o vault-operator-helper .
 
 # Use a minimal runtime image
 FROM alpine:latest


### PR DESCRIPTION
## Summary

Safe-only fixes to CI configuration and the Dockerfile. No application code is changed.

### CI (`ci.yml`)
- **Drop the misleading Go version matrix** (`1.21`–`1.26`). `go.mod` requires `go 1.26.0`, so under `GOTOOLCHAIN=auto` every matrix job actually downloaded and built on 1.26 — the matrix was pointless and wasteful. Now uses `go-version-file: go.mod` as the single source of truth.
- **Add `gofmt` and `go vet` checks** so formatting/suspicious-construct regressions are caught in CI.
- **Bump actions**: `actions/checkout` v3 → v4, `actions/setup-go` v4 → v5.

### Dockerfile
- Build the package (`go build -o vault-operator-helper .`) instead of a single file (`main.go`), so the image keeps building if the code is ever split across multiple files.

## Verification (local)
- `gofmt -l .` → clean
- `make vet` ✅
- `make test` ✅
- `CGO_ENABLED=0 GOOS=linux go build -o ... .` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)