### PR TITLE
Use informer lister, context-aware shutdown, and standard logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -16,8 +18,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
@@ -30,8 +34,9 @@ var (
 	watchKey           string
 	mainContainerName  string
 
-	clientset kubernetes.Interface
-	lock      sync.Mutex
+	clientset       kubernetes.Interface
+	namespaceLister corelisters.NamespaceLister
+	lock            sync.Mutex
 
 	// restartMainContainer is the action used to reload the ConfigMap.
 	// It is a variable so tests can override it.
@@ -53,38 +58,31 @@ func main() {
 
 	config, err := getKubeConfig()
 	if err != nil {
-		fmt.Printf("Error getting Kubernetes config: %v\n", err)
-		os.Exit(1)
+		log.Fatalf("Error getting Kubernetes config: %v", err)
 	}
 
 	clientset, err = kubernetes.NewForConfig(config)
 	if err != nil {
-		fmt.Printf("Error creating Kubernetes client: %v\n", err)
-		os.Exit(1)
+		log.Fatalf("Error creating Kubernetes client: %v", err)
 	}
 
-	// Ensure the ConfigMap is created/updated at startup
-	updateConfigMap()
+	// Cancel the context on SIGTERM/SIGINT for graceful shutdown.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
 
-	// Set up signal handling for graceful shutdown
-	stopCh := make(chan struct{})
-	signalCh := make(chan os.Signal, 1)
+	// Start the namespace watcher and wait for its cache to sync.
+	if err := watchNamespaces(ctx); err != nil {
+		log.Fatalf("Error starting namespace watcher: %v", err)
+	}
 
-	// Listen for termination signals
-	signal.Notify(signalCh, syscall.SIGTERM, syscall.SIGINT)
+	// Ensure the ConfigMap reflects the current state once the cache is synced.
+	// This also covers the case where no matching namespace exists yet, for
+	// which no informer Add event would fire.
+	updateConfigMap(ctx)
 
-	go func() {
-		<-signalCh
-		fmt.Println("Received termination signal. Shutting down gracefully...")
-		close(stopCh) // Stop the namespace watcher
-		os.Exit(0)    // Exit the program
-	}()
-
-	// Start namespace watcher
-	go watchNamespaces(stopCh)
-
-	// Keep the program running
-	<-stopCh
+	// Block until a termination signal cancels the context.
+	<-ctx.Done()
+	log.Println("Received termination signal. Shutting down gracefully...")
 }
 
 // getKubeConfig tries in-cluster config first, then falls back to local kubeconfig
@@ -92,12 +90,12 @@ func getKubeConfig() (*rest.Config, error) {
 	// Try in-cluster config
 	config, err := rest.InClusterConfig()
 	if err == nil {
-		fmt.Println("Using in-cluster configuration")
+		log.Println("Using in-cluster configuration")
 		return config, nil
 	}
 
 	// Fall back to local kubeconfig
-	fmt.Println("In-cluster config failed, falling back to local kubeconfig")
+	log.Println("In-cluster config failed, falling back to local kubeconfig")
 	kubeconfig := filepath.Join(os.Getenv("HOME"), ".kube", "config")
 	if envKubeconfig := os.Getenv("KUBECONFIG"); envKubeconfig != "" {
 		kubeconfig = envKubeconfig
@@ -108,48 +106,54 @@ func getKubeConfig() (*rest.Config, error) {
 		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
 
-	fmt.Println("Using local kubeconfig")
+	log.Println("Using local kubeconfig")
 	return config, nil
 }
 
-// watchNamespaces monitors namespace creation and deletion
-func watchNamespaces(stopCh chan struct{}) {
+// watchNamespaces starts an informer that monitors namespace changes and keeps
+// the ConfigMap in sync. It returns once the informer cache has synced; the
+// informer keeps running in the background until ctx is cancelled.
+func watchNamespaces(ctx context.Context) error {
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(clientset, time.Minute, informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
 		opts.LabelSelector = labelSelector
 	}))
-	namespaceInformer := informerFactory.Core().V1().Namespaces().Informer()
+	namespaceInformer := informerFactory.Core().V1().Namespaces()
+	namespaceLister = namespaceInformer.Lister()
 
-	namespaceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { updateConfigMap() },
-		UpdateFunc: func(oldObj, newObj interface{}) { updateConfigMap() },
-		DeleteFunc: func(obj interface{}) { updateConfigMap() },
+	namespaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { updateConfigMap(ctx) },
+		UpdateFunc: func(oldObj, newObj interface{}) { updateConfigMap(ctx) },
+		DeleteFunc: func(obj interface{}) { updateConfigMap(ctx) },
 	})
 
-	informerFactory.Start(stopCh)
-	informerFactory.WaitForCacheSync(stopCh)
+	informerFactory.Start(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), namespaceInformer.Informer().HasSynced) {
+		return fmt.Errorf("failed to sync namespace informer cache")
+	}
+	return nil
 }
 
 // updateConfigMap updates the ConfigMap with the latest namespace list
-func updateConfigMap() {
+func updateConfigMap(ctx context.Context) {
 	lock.Lock()
 	defer lock.Unlock()
 
 	namespaces, err := getFilteredNamespaces()
 	if err != nil {
-		fmt.Printf("Error getting namespaces: %v\n", err)
+		log.Printf("Error getting namespaces: %v", err)
 		return
 	}
 
 	newValue := strings.Join(namespaces, ",")
 
 	// Fetch the existing ConfigMap
-	cm, err := clientset.CoreV1().ConfigMaps(configMapNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+	cm, err := clientset.CoreV1().ConfigMaps(configMapNamespace).Get(ctx, configMapName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// If ConfigMap doesn't exist, create it
-			createConfigMap(newValue)
+			createConfigMap(ctx, newValue)
 		} else {
-			fmt.Printf("Error getting ConfigMap: %v\n", err)
+			log.Printf("Error getting ConfigMap: %v", err)
 		}
 		return
 	}
@@ -164,9 +168,8 @@ func updateConfigMap() {
 		cm.Data = make(map[string]string)
 	}
 	cm.Data[watchKey] = newValue
-	_, err = clientset.CoreV1().ConfigMaps(configMapNamespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
-	if err != nil {
-		fmt.Printf("Error updating ConfigMap: %v\n", err)
+	if _, err := clientset.CoreV1().ConfigMaps(configMapNamespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+		log.Printf("Error updating ConfigMap: %v", err)
 		return
 	}
 
@@ -174,24 +177,31 @@ func updateConfigMap() {
 	restartMainContainer()
 }
 
-// getFilteredNamespaces retrieves namespaces with the specified label
+// getFilteredNamespaces retrieves namespaces with the specified label from the
+// informer cache. The result is sorted so the joined value is stable and does
+// not trigger spurious ConfigMap updates (and container restarts) caused by
+// non-deterministic cache iteration order.
 func getFilteredNamespaces() ([]string, error) {
-	namespaces, err := clientset.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: labelSelector,
-	})
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("invalid label selector %q: %w", labelSelector, err)
+	}
+
+	namespaces, err := namespaceLister.List(selector)
 	if err != nil {
 		return nil, err
 	}
 
-	var nsList []string
-	for _, ns := range namespaces.Items {
+	nsList := make([]string, 0, len(namespaces))
+	for _, ns := range namespaces {
 		nsList = append(nsList, ns.Name)
 	}
+	sort.Strings(nsList)
 	return nsList, nil
 }
 
 // createConfigMap creates a new ConfigMap
-func createConfigMap(value string) {
+func createConfigMap(ctx context.Context, value string) {
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configMapName,
@@ -202,27 +212,25 @@ func createConfigMap(value string) {
 		},
 	}
 
-	_, err := clientset.CoreV1().ConfigMaps(configMapNamespace).Create(context.TODO(), cm, metav1.CreateOptions{})
-	if err != nil {
-		fmt.Printf("Error creating ConfigMap: %v\n", err)
+	if _, err := clientset.CoreV1().ConfigMaps(configMapNamespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+		log.Printf("Error creating ConfigMap: %v", err)
 	}
 }
 
 // killMainContainer kills the main container to reload the ConfigMap
 func killMainContainer() {
-	fmt.Println("Restarting main container...")
+	log.Println("Restarting main container...")
 
 	// Find the main container's PID (assumes PID namespace is shared)
 	pid, err := getMainContainerPID()
 	if err != nil {
-		fmt.Printf("Error getting main container PID: %v\n", err)
+		log.Printf("Error getting main container PID: %v", err)
 		return
 	}
 
 	// Send SIGTERM to the main container
-	err = exec.Command("kill", "-SIGTERM", pid).Run()
-	if err != nil {
-		fmt.Printf("Error sending SIGTERM to main container: %v\n", err)
+	if err := exec.Command("kill", "-SIGTERM", pid).Run(); err != nil {
+		log.Printf("Error sending SIGTERM to main container: %v", err)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -7,12 +7,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
 // setupTest configures the package globals for a test run and returns the fake
-// clientset so assertions can be made against it. The main-container restart is
-// stubbed out so tests never shell out to pgrep/kill.
+// clientset so assertions can be made against it. A namespace lister backed by
+// the fake clientset is wired up the same way production does, and the
+// main-container restart is stubbed out so tests never shell out to pgrep/kill.
 func setupTest(t *testing.T, objects ...runtime.Object) *fake.Clientset {
 	t.Helper()
 
@@ -21,22 +23,33 @@ func setupTest(t *testing.T, objects ...runtime.Object) *fake.Clientset {
 	configMapName = "watch-namespace-config"
 	configMapNamespace = "vault"
 	watchKey = "WATCH_NAMESPACE"
-	// Empty selector: the fake clientset does not apply label-selector filtering,
-	// so keep tests independent of that behaviour.
+	// Empty selector matches every namespace; the lister applies the selector
+	// in-memory, so tests stay independent of any pre-filtering.
 	labelSelector = ""
 
 	clientset = cs
 
+	// Build and sync a namespace lister from the fake clientset.
+	factory := informers.NewSharedInformerFactory(cs, 0)
+	namespaceLister = factory.Core().V1().Namespaces().Lister()
+	stopCh := make(chan struct{})
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
 	restartMainContainer = func() {}
-	t.Cleanup(func() { restartMainContainer = killMainContainer })
+	t.Cleanup(func() {
+		close(stopCh)
+		restartMainContainer = killMainContainer
+		namespaceLister = nil
+	})
 
 	return cs
 }
 
 func TestGetFilteredNamespaces(t *testing.T) {
 	setupTest(t,
-		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-a"}},
 		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-b"}},
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-a"}},
 	)
 
 	got, err := getFilteredNamespaces()
@@ -44,13 +57,15 @@ func TestGetFilteredNamespaces(t *testing.T) {
 		t.Fatalf("getFilteredNamespaces returned error: %v", err)
 	}
 
-	want := map[string]bool{"team-a": true, "team-b": true}
+	// Result must be sorted for a stable, restart-friendly ConfigMap value.
+	want := []string{"team-a", "team-b"}
 	if len(got) != len(want) {
-		t.Fatalf("got %d namespaces (%v), want %d", len(got), got, len(want))
+		t.Fatalf("got %d namespaces (%v), want %v", len(got), got, want)
 	}
-	for _, ns := range got {
-		if !want[ns] {
-			t.Errorf("unexpected namespace %q in result", ns)
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got %v, want %v (not sorted)", got, want)
+			break
 		}
 	}
 }
@@ -60,7 +75,7 @@ func TestUpdateConfigMap_CreatesWhenMissing(t *testing.T) {
 		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-a"}},
 	)
 
-	updateConfigMap()
+	updateConfigMap(context.Background())
 
 	cm, err := cs.CoreV1().ConfigMaps(configMapNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
 	if err != nil {
@@ -83,7 +98,7 @@ func TestUpdateConfigMap_NilData(t *testing.T) {
 	)
 
 	// Would panic before the nil-map guard was added.
-	updateConfigMap()
+	updateConfigMap(context.Background())
 
 	cm, err := cs.CoreV1().ConfigMaps(configMapNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
 	if err != nil {
@@ -103,7 +118,7 @@ func TestUpdateConfigMap_NoChangeKeepsValue(t *testing.T) {
 		},
 	)
 
-	updateConfigMap()
+	updateConfigMap(context.Background())
 
 	cm, err := cs.CoreV1().ConfigMaps(configMapNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
## Summary

The three deferred code improvements to `main.go`. Behaviour-preserving except where noted (the lister sort fixes a latent spurious-restart bug).

### Informer lister instead of repeated List calls
- `updateConfigMap` previously issued a fresh `Namespaces().List()` API call on every informer event. It now reads from the informer's cached **lister** — the data is already in memory.
- **Sort the namespace list.** The lister iterates a map-backed cache in non-deterministic order; without sorting, the comma-joined value could change between events even when the namespace set is identical, flipping the ConfigMap and triggering an unnecessary main-container restart. Sorting makes the value stable.

### Context-aware graceful shutdown
- Replaced the ad-hoc `stopCh` + `signalCh` + `os.Exit(0)` (which skipped deferred cleanup) with `signal.NotifyContext`.
- The context is threaded through the ConfigMap `Get`/`Update`/`Create` calls (no more `context.TODO()`), so in-flight requests are cancelled on shutdown.
- A cache-sync failure is now a fatal startup error instead of being silently ignored.

### Standard logging
- Switched `fmt.Printf`/`fmt.Println` logging to the standard `log` package (timestamps), and `log.Fatalf` for startup failures.

## Tests
`main_test.go` now builds and syncs a namespace lister from the fake clientset (mirroring production) and asserts the sorted ordering. All existing assertions retained, including the nil-map panic regression test.

## Verification (local)
- `gofmt -l .` → clean
- `go vet ./...` ✅
- `make test` ✅ (4 tests pass)
- `make build` (`-race`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)